### PR TITLE
MGMT-20272: Cluster attribute finalizing_stage_started_at show wrong …

### DIFF
--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -1838,11 +1838,14 @@ func (m *Manager) UpdateFinalizingStage(ctx context.Context, clusterID strfmt.UU
 		return common.NewApiError(http.StatusBadRequest, errors.Errorf("cluster is %s, not in one of allowed statuses: %v", swag.StringValue(cls.Status), allowedStatuses))
 	}
 	if cls.Progress == nil || cls.Progress.FinalizingStage != finalizingStage {
-		if err = m.db.Model(&common.Cluster{}).Where("id = ?", clusterID.String()).Updates(map[string]interface{}{
-			"progress_finalizing_stage":            finalizingStage,
-			"progress_finalizing_stage_started_at": time.Now(),
-			"progress_finalizing_stage_timed_out":  false,
-		}).Error; err != nil {
+		updates := map[string]interface{}{
+			"progress_finalizing_stage":           finalizingStage,
+			"progress_finalizing_stage_timed_out": false,
+		}
+		if cls.Progress.FinalizingStage == "" {
+			updates["progress_finalizing_stage_started_at"] = time.Now()
+		}
+		if err = m.db.Model(&common.Cluster{}).Where("id = ?", clusterID.String()).Updates(updates).Error; err != nil {
 			return common.NewApiError(http.StatusInternalServerError, errors.Wrapf(err, "update finalizing stage for cluster %s", clusterID.String()))
 		}
 		eventgen.SendClusterFinalizingStageUpdatedEvent(ctx, m.eventsHandler, clusterID, string(finalizingStage))


### PR DESCRIPTION
…value

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of finalizing stage progress to ensure the stage start time is set only once at the beginning, preventing unnecessary timestamp updates on subsequent changes.

- **Tests**
  - Added a test to verify that the finalizing stage start time is recorded only at the initial stage transition and remains unchanged on further updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->